### PR TITLE
Addition of "Clone" feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ $opts - the options array:
 
 - join - common root name if any source has different root name (default is *root*, specifying *false* denies different names)
 - updn - traverse the nodes by name sequence (*true*, default) or overall sequence (*false*)
-- stay - the *stay* attribute value to deny overwriting of specific node (default is *all*, can be array of values or empty)
+- stay - use the *stay* attribute value to deny overwriting of specific node (default is *all*, can be array of values, string or empty)
+- clone - use the *clone* attribute value to clone specific nodes if they already exists (empty by default, can be array of values, string or empty)
 
 **$oMX->AddFile($file)**;
 
@@ -75,6 +76,7 @@ ChangeLog
 
 - *mergexml.php*
  - *stay* parameter is added for *AddFile* and *AddSource* methods
+ - *clone* parameter is added for *AddFile* and *AddSource* methods
  - *NameSpaces* method is added to register/xpath 1st (single) source
 
   [github.com]: http://www.github.com/hareko/js-merge-xml

--- a/README.md
+++ b/README.md
@@ -76,7 +76,11 @@ ChangeLog
 
 - *mergexml.php*
  - *stay* parameter is added for *AddFile* and *AddSource* methods
- - *clone* parameter is added for *AddFile* and *AddSource* methods
  - *NameSpaces* method is added to register/xpath 1st (single) source
+
+11 July 2014
+
+- *mergexml.php*
+ - *clone* parameter is added for *AddFile* and *AddSource* methods
 
   [github.com]: http://www.github.com/hareko/js-merge-xml


### PR DESCRIPTION
## Quick description

This update adds the ability to clone certain nodes. It works similar to the "Stay" feature already included on the class... but this time, when the selected nodes are found on the XML, they will be added without replacing the existing ones.
## Examples

Clone nodes as parameters added to the constructor

> $oMX = new MergeXML( array("clone" => "item") );

Clone nodes as parameters included on the AddFile/AddSource methods

> $oMX->AddFile( $fileURL, null, array("object") );
> $oMX->AddSource( $xmlString, null, array("autor") );
## Notes
- The "Stay" behavior was also updated in order to match the _tagName_ of each node with the array of "Stay" nodes. The script was looking for an attribute named "stay" on the nodes to match the array values before the update.
- The nodes selected to be cloned doesn't need to be marked as "stay" to avoid overwrite.
- The updates doesn't conflict with the "Stay" feature, it is possible to use both at once. Example:

> $oMX->AddSource( $xmlString,  array("object","item"), array("autor") );
